### PR TITLE
Updated dependencies and wrote an introductory README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# IntelliJ project files
+.idea
+*.iml
+out
+gen
+
+# npm
+node_modules
+.env
+yarn-error.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
-# IntelliJ project files
-.idea
-*.iml
-out
-gen
-
 # npm
 node_modules
 .env

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Free Code Camp - Applied InfoSec Challenges
 =============================================
 
-This is the repository for the freeCodeCamp [Information Security with HelmetJS Challenges](https://learn.freecodecamp.org/information-security-and-quality-assurance/information-security-with-helmetjs/).  
+This is the repository for the first 11 freeCodeCamp [Information Security with HelmetJS Challenges](https://learn.freecodecamp.org/information-security-and-quality-assurance/information-security-with-helmetjs/).  
+For the challenges from the 12th on upwards, you have to clone [this one](https://github.com/freeCodeCamp/boilerplate-bcrypt). 
+
 If you haven't worked with **git** before, you might first want to read a few   
 [resources](http://try.github.io/) about it, or go the [Glitch](https://glitch.com/) 
 way as described on the above mentioned challenge introduction page.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # Free Code Camp - Applied InfoSec Challenges
 =============================================
+
+This is the repository for the freeCodeCamp [Information Security with HelmetJS Challenges](https://learn.freecodecamp.org/information-security-and-quality-assurance/information-security-with-helmetjs/).  
+If you haven't worked with **git** before, you might first want to read a few   
+[resources](http://try.github.io/) about it, or go the [Glitch](https://glitch.com/) 
+way as described on the above mentioned challenge introduction page.
+
+To clone this Repository, go to a directory of your choice and enter:
+```
+git clone https://github.com/freeCodeCamp/boilerplate-infosec.git
+cd boilerplate-infosec
+```
+But to be able to import it in Glitch or the coding platform of your choice,  
+you have to [create your own Repository on GitHub](https://help.github.com/articles/creating-a-new-repository/).  
+But before you are able to push to it, you have to remove the remote origin of
+freeCodeCamp,   
+rename the "gomix" branch to "master" and delete the gomix branch
+to have a clutter free Repository:
+```
+git remote remove origin
+git branch -m master
+git branch -d gomix
+```
+Then follow the steps outlined in **...or push an existing repository from the command line**  
+on the **Quick setup** screen, e.g.:
+```
+git remote add origin git@github.com:<yourname>/<your_repository>.git
+git push -u origin master
+```
+
+Now you should have a fully functional Repository you can import to a coding platform.  
+But to develop locally, there is one more step necessary, run:
+```
+npm install
+```
+
+Don't forget to commit and push your changes after each challenge step (and, 
+depending on your coding platform      
+of choice, reimport it there), so freeCodeCamp is able to test your results!  
+
+*Happy Coding!*

--- a/README.md
+++ b/README.md
@@ -9,21 +9,28 @@ If you haven't used **git** before, you might want to first read
 way as described on the challenge introduction page mentioned above.
 
 To clone this repository, go to a directory of your choice and run:
-```bash
+
+```
 git clone https://github.com/freeCodeCamp/boilerplate-infosec.git
 cd boilerplate-infosec
 ```
-In order to be able to import your local clone to Glitch (or any other coding platform of your choice),  
+
+In order to be able to import your local clone to Glitch (or any other coding 
+platform of your choice),  
 you have to [create your own repository on GitHub](https://help.github.com/articles/creating-a-new-repository/), or [fork this repository](https://help.github.com/articles/fork-a-repo/).
 To be able to push to it, you have to remove the remote `origin`,
 rename the "gomix" branch to "master" and delete the gomix branch
 (to have a clutter-free repository):
+
 ```
 git remote remove origin
 git branch -m master
 git branch -d gomix
 ```
-Then follow the steps outlined in the **Quick setup** screen (you could also push to some other existing repository from the command line):
+
+Then follow the steps outlined in the **Quick setup** screen (you could also push 
+to some other existing repository from the command line):
+
 ```
 git remote add origin git@github.com:<yourname>/<your_repository>.git
 git push -u origin master
@@ -31,6 +38,7 @@ git push -u origin master
 
 Now you should have a fully functional repository you can import to any coding platform.
 In order to develop locally, there is one more step necessary. Run:
+
 ```
 npm install
 ```

--- a/README.md
+++ b/README.md
@@ -2,43 +2,41 @@
 =============================================
 
 This is the repository for the first 11 freeCodeCamp [Information Security with HelmetJS Challenges](https://learn.freecodecamp.org/information-security-and-quality-assurance/information-security-with-helmetjs/).  
-For the challenges from the 12th on upwards, you have to clone [this one](https://github.com/freeCodeCamp/boilerplate-bcrypt). 
+For the 12th challenge and upwards, you will have to clone [this repository](https://github.com/freeCodeCamp/boilerplate-bcrypt). 
 
-If you haven't worked with **git** before, you might first want to read a few   
-[resources](http://try.github.io/) about it, or go the [Glitch](https://glitch.com/) 
-way as described on the above mentioned challenge introduction page.
+If you haven't used **git** before, you might want to first read
+[a bit](http://try.github.io/) about it, or try the [Glitch](https://glitch.com/) 
+way as described on the challenge introduction page mentioned above.
 
-To clone this Repository, go to a directory of your choice and enter:
-```
+To clone this repository, go to a directory of your choice and run:
+```bash
 git clone https://github.com/freeCodeCamp/boilerplate-infosec.git
 cd boilerplate-infosec
 ```
-But to be able to import it in Glitch or the coding platform of your choice,  
-you have to [create your own Repository on GitHub](https://help.github.com/articles/creating-a-new-repository/).  
-But before you are able to push to it, you have to remove the remote origin of
-freeCodeCamp,   
+In order to be able to import your local clone to Glitch (or any other coding platform of your choice),  
+you have to [create your own repository on GitHub](https://help.github.com/articles/creating-a-new-repository/), or [fork this repository](https://help.github.com/articles/fork-a-repo/).
+To be able to push to it, you have to remove the remote `origin`,
 rename the "gomix" branch to "master" and delete the gomix branch
-to have a clutter free Repository:
+(to have a clutter-free repository):
 ```
 git remote remove origin
 git branch -m master
 git branch -d gomix
 ```
-Then follow the steps outlined in **...or push an existing repository from the command line**  
-on the **Quick setup** screen, e.g.:
+Then follow the steps outlined in the **Quick setup** screen (you could also push to some other existing repository from the command line):
 ```
 git remote add origin git@github.com:<yourname>/<your_repository>.git
 git push -u origin master
 ```
 
-Now you should have a fully functional Repository you can import to a coding platform.  
-But to develop locally, there is one more step necessary, run:
+Now you should have a fully functional repository you can import to any coding platform.
+In order to develop locally, there is one more step necessary. Run:
 ```
 npm install
 ```
 
 Don't forget to commit and push your changes after each challenge step (and, 
 depending on your coding platform      
-of choice, reimport it there), so freeCodeCamp is able to test your results!  
+of choice, reimport it there), so that freeCodeCamp is able to test your results!  
 
 *Happy Coding!*

--- a/README.md
+++ b/README.md
@@ -49,3 +49,10 @@ depending on your coding platform
 of choice, reimport it there), so that freeCodeCamp is able to test your results!  
 
 *Happy Coding!*
+
+#### Informational
+
+You might want to take a look at [this page](https://help.github.com/articles/ignoring-files/#create-a-global-gitignore)
+for information about a global `.gitignore` file, so you won't accidentally commit
+and push your IDE's of choice helper files.
+

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ git remote add origin git@github.com:<yourname>/<your_repository>.git
 git push -u origin master
 ```
 
-Now you should have a fully functional repository you can import to any coding platform.
+Now you should have a fully functional repository you can import to any coding platform.  
+**Important:**
 In order to develop locally, there is one more step necessary. Run:
 
 ```

--- a/myApp.js
+++ b/myApp.js
@@ -177,7 +177,7 @@ var ninetyDaysInMilliseconds = 90*24*60*60*1000;
 
 
 
-/** TIP: */ 
+/** 11) Configure Helmet using the ‘parent’ Middleware `helmet()` */
 
 // `app.use(helmet())` will automatically include all the middleware
 // presented above, except `noCache()`, and `contentSecurityPolicy()`,
@@ -201,6 +201,13 @@ var ninetyDaysInMilliseconds = 90*24*60*60*1000;
 // We introduced each middleware separately, for teaching purpose, and for
 // ease of testing. Using the 'parent' `helmet()` middleware is easiest, and
 // cleaner, for a real project.
+
+
+
+/**
+ * For the challenges 12), 13) & 14) you have to switch to the Repository:
+ * https://github.com/freeCodeCamp/boilerplate-bcrypt/
+ */
 
 // ---- DO NOT EDIT BELOW THIS LINE ---------------------------------------
 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
 		"start": "node myApp.js"
 	},
 	"dependencies": {
-		"express": "^4.14.0"
+		"express": "^4.16.3"
 	},
 	"engines": {
-		"node": "4.4.5"
+		"node": "8.x"
 	},
 	"keywords": [
 		"node",


### PR DESCRIPTION
Although this PR does nearly the same as my one for [boilerplate-mongomongoose](https://github.com/freeCodeCamp/boilerplate-mongomongoose/pull/8),  
I think these changes are worth it.

As Glitch was always complaining about "4.4.5" not being an available Node.js version, 
and (developing locally) yarn would strike completely, I changed the following:

- [x] added `.gitignore` to prevent pushing `node_modules` and IDE files
- [x] updated Node.js in package.json to 8.x
- [x] updated **express** to latest stable version (^4.16.3)
- [x] added a meaningful introduction and warnings to `README.md`
- [x] added a warning to the end of `myApp.js` to switch Repositories to bcrypt

These changes won't break anything but might stop irritating students with error messages
when starting the challenges.

One more thought:
Perhaps this Repository should be merged with the [boilerplate-bcrypt](https://github.com/freeCodeCamp/boilerplate-bcrypt) one.
I'd be happy to look at it and combine the server code, too.