### PR TITLE
fix: Remove engine from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
 	"dependencies": {
 		"express": "^4.14.0"
 	},
-	"engines": {
-		"node": "4.4.5"
-	},
 	"keywords": [
 		"node",
 		"hyperdev",


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Removes the `engine` field from the `package.json` per http://github.com/freeCodeCamp/freeCodeCamp/issues/40365